### PR TITLE
Add dual package publishing support for ESM and CommonJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,17 @@ const re = regex({plugins: [recursion]})`…`;
 ```
 
 <details>
+  <summary>Using CommonJS require</summary>
+
+```js
+const {regex} = require('regex');
+const {recursion} = require('regex-recursion');
+
+const re = regex({plugins: [recursion]})`…`;
+```
+</details>
+
+<details>
   <summary>Using a global name (no import)</summary>
 
 ```html

--- a/package.json
+++ b/package.json
@@ -2,33 +2,24 @@
   "name": "regex-recursion",
   "version": "6.0.2",
   "description": "Recursive matching plugin for Regex+",
-  "keywords": [
-    "recursion",
-    "regex",
-    "regexp"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/slevithan/regex-recursion.git"
-  },
-  "license": "MIT",
   "author": "Steven Levithan",
+  "license": "MIT",
   "type": "module",
   "exports": {
     ".": {
-      "types": "./types/index.d.ts",
-      "import": "./src/index.js",
-      "require": "./dist/cjs/index.cjs"
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./src/index.js"
+      },
+      "require": {
+        "types": "./types/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
     }
   },
   "main": "./dist/cjs/index.cjs",
   "browser": "./dist/regex-recursion.min.js",
   "types": "./types/index.d.ts",
-  "files": [
-    "dist",
-    "src",
-    "types"
-  ],
   "scripts": {
     "prebuild": "rm -rf dist/* types/*",
     "build": "pnpm run bundle:global && pnpm run bundle:cjs && pnpm run types",
@@ -37,8 +28,22 @@
     "prepare": "pnpm test",
     "pretest": "pnpm run build",
     "test": "jasmine",
-    "types": "tsc src/index.js --rootDir src --declaration --allowJs --emitDeclarationOnly --outDir types"
+    "types": "tsc src/index.js --rootDir src --declaration --allowJs --emitDeclarationOnly --outDir types && cp types/index.d.ts types/index.d.cts"
   },
+  "files": [
+    "dist",
+    "src",
+    "types"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/slevithan/regex-recursion.git"
+  },
+  "keywords": [
+    "recursion",
+    "regex",
+    "regexp"
+  ],
   "dependencies": {
     "regex-utilities": "^2.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -2,40 +2,43 @@
   "name": "regex-recursion",
   "version": "6.0.2",
   "description": "Recursive matching plugin for Regex+",
-  "author": "Steven Levithan",
-  "license": "MIT",
-  "type": "module",
-  "exports": {
-    ".": {
-      "types": "./types/index.d.ts",
-      "import": "./src/index.js"
-    }
-  },
-  "browser": "./dist/regex-recursion.min.js",
-  "types": "./types/index.d.ts",
-  "scripts": {
-    "bundle:global": "esbuild src/index.js --global-name=Regex.plugins --bundle --minify --sourcemap --outfile=dist/regex-recursion.min.js",
-    "types": "tsc src/index.js --rootDir src --declaration --allowJs --emitDeclarationOnly --outDir types",
-    "prebuild": "rm -rf dist/* types/*",
-    "build": "pnpm run bundle:global && pnpm run types",
-    "pretest": "pnpm run build",
-    "test": "jasmine",
-    "prepare": "pnpm test"
-  },
-  "files": [
-    "dist",
-    "src",
-    "types"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/slevithan/regex-recursion.git"
-  },
   "keywords": [
     "recursion",
     "regex",
     "regexp"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/slevithan/regex-recursion.git"
+  },
+  "license": "MIT",
+  "author": "Steven Levithan",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./src/index.js",
+      "require": "./dist/cjs/index.js"
+    }
+  },
+  "main": "./dist/cjs/index.js",
+  "browser": "./dist/regex-recursion.min.js",
+  "types": "./types/index.d.ts",
+  "files": [
+    "dist",
+    "src",
+    "types"
+  ],
+  "scripts": {
+    "prebuild": "rm -rf dist/* types/*",
+    "build": "pnpm run bundle:global && pnpm run bundle:cjs && pnpm run types",
+    "bundle:cjs": "esbuild src/index.js --format=cjs --bundle --outfile=dist/cjs/index.js",
+    "bundle:global": "esbuild src/index.js --global-name=Regex.plugins --bundle --minify --sourcemap --outfile=dist/regex-recursion.min.js",
+    "prepare": "pnpm test",
+    "pretest": "pnpm run build",
+    "test": "jasmine",
+    "types": "tsc src/index.js --rootDir src --declaration --allowJs --emitDeclarationOnly --outDir types"
+  },
   "dependencies": {
     "regex-utilities": "^2.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     ".": {
       "types": "./types/index.d.ts",
       "import": "./src/index.js",
-      "require": "./dist/cjs/index.js"
+      "require": "./dist/cjs/index.cjs"
     }
   },
-  "main": "./dist/cjs/index.js",
+  "main": "./dist/cjs/index.cjs",
   "browser": "./dist/regex-recursion.min.js",
   "types": "./types/index.d.ts",
   "files": [
@@ -32,7 +32,7 @@
   "scripts": {
     "prebuild": "rm -rf dist/* types/*",
     "build": "pnpm run bundle:global && pnpm run bundle:cjs && pnpm run types",
-    "bundle:cjs": "esbuild src/index.js --format=cjs --bundle --outfile=dist/cjs/index.js",
+    "bundle:cjs": "esbuild src/index.js --format=cjs --bundle --outfile=dist/cjs/index.cjs",
     "bundle:global": "esbuild src/index.js --global-name=Regex.plugins --bundle --minify --sourcemap --outfile=dist/regex-recursion.min.js",
     "prepare": "pnpm test",
     "pretest": "pnpm run build",

--- a/spec/cjs-support-spec.cjs
+++ b/spec/cjs-support-spec.cjs
@@ -1,0 +1,17 @@
+// This file uses CommonJS syntax to test the CJS compatibility
+const {recursion} = require('../dist/cjs/index.cjs');
+
+describe('CommonJS support', () => {
+  it('should export recursion function via require()', () => {
+    expect(typeof recursion).toBe('function');
+  });
+
+  it('should have proper function behavior', () => {
+    const pattern = 'a(?R=2)?b';
+    const result = recursion(pattern);
+    
+    expect(result.pattern).toBe('a(?:a(?:)?b)?b');
+    expect(result.captureTransfers instanceof Map).toBe(true);
+    expect(Array.isArray(result.hiddenCaptures)).toBe(true);
+  });
+}); 

--- a/spec/esm-support-spec.js
+++ b/spec/esm-support-spec.js
@@ -1,0 +1,19 @@
+// This file uses ESM syntax to test the ESM compatibility
+import { recursion } from '../src/index.js';
+
+describe('ESM support', () => {
+  it('should export recursion function via import', () => {
+    expect(typeof recursion).toBe('function');
+  });
+  
+  it('should have proper function behavior', () => {
+    const pattern = 'a(?R=2)?b';
+    const result = recursion(pattern);
+    
+    expect(result).toEqual({
+      pattern: 'a(?:a(?:)?b)?b',
+      captureTransfers: jasmine.any(Map),
+      hiddenCaptures: []
+    });
+  });
+}); 

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,7 +1,8 @@
 {
   "spec_dir": "spec",
   "spec_files": [
-    "*-spec.js"
+    "*-spec.js",
+    "*-spec.cjs"
   ],
   "helpers": [
     "helpers/**/*.?(m)js"


### PR DESCRIPTION
This MR supports dual package publishing, allowing the package to be consumed by ESM and CommonJS projects without any breaking changes.

### Changes

- Added CommonJS output format to the build process (with .cjs extension)
- Updated package.json exports field to include both ESM and CommonJS entry points
- Added "main" field for CommonJS compatibility
- Updated the README to document CommonJS usage
- Added tests to verify both ESM and CommonJS imports work correctly
- Sorted `package.json` 🙈

### Benefits

- Broader compatibility with different project types and configurations
- Existing ESM imports continue to work without changes
- CommonJS users can now use the package with `require()`
- No breaking changes for existing projects